### PR TITLE
#35 - 삭제 수정 로직인데 컨트롤러에서 post와 get만 사용하는 이유 주석으로 명시

### DIFF
--- a/src/main/java/com/example/board/controller/ArticleCommentController.java
+++ b/src/main/java/com/example/board/controller/ArticleCommentController.java
@@ -26,6 +26,9 @@ public class ArticleCommentController {
         return "redirect:/articles/" + articleCommentRequest.articleId();
     }
 
+    // 삭제 요청인데도 @PostMapping을 사용하는 이유는 form-data는 기본적으로 get과 post만 허용하기 때문이다.
+    // 물론 타임리프를 사용하면 put과 delete 맵핑을 하고 타임리프 코드에 메서드로 put, delete로 넣어주면 알아서 편법으로 변환해주기 때문에 사용이 가능하지만
+    // http 표준 스펙을 지기키 위해서 form-data가 허용하는 메서드만 사용하였다.
     @PostMapping("/{commentId}/delete")
     public String deleteArticleComment(@PathVariable Long commentId, Long articleId) {
         articleCommentService.deleteArticleComment(commentId);


### PR DESCRIPTION
삭제 요청인데도 @PostMapping을 사용하는 이유는 form-data는 기본적으로 get과 post만 허용하기 때문이다. 물론 타임리프를 사용하면 put과 delete 맵핑을 하고 타임리프 코드에 메서드로 put, delete로 넣어주면 알아서 편법으로 변환해주기 때문에 사용이 가능하지만, http 표준 스펙을 지기키 위해서 form-data가 허용하는 메서드만 사용하였다.